### PR TITLE
Enable staged curriculum training for Wan 2.2

### DIFF
--- a/src/musubi_tuner/dataset/config_utils.py
+++ b/src/musubi_tuner/dataset/config_utils.py
@@ -34,6 +34,7 @@ class BaseDatasetParams:
     cache_directory: Optional[str] = None
     debug_dataset: bool = False
     architecture: str = "no_default"  # short style like "hv" or "wan"
+    stage: int = 1
 
 
 @dataclass
@@ -109,6 +110,7 @@ class ConfigSanitizer:
         "resolution": functools.partial(__validate_and_convert_scalar_or_twodim.__func__, int),
         "enable_bucket": bool,
         "bucket_no_upscale": bool,
+        "stage": int,
     }
     IMAGE_DATASET_DISTINCT_SCHEMA = {
         "image_directory": str,
@@ -292,6 +294,7 @@ def generate_dataset_group_by_blueprint(
         resolution: {dataset.resolution}
         batch_size: {dataset.batch_size}
         num_repeats: {dataset.num_repeats}
+        stage: {getattr(dataset, 'stage', 1)}
         caption_extension: "{dataset.caption_extension}"
         enable_bucket: {dataset.enable_bucket}
         bucket_no_upscale: {dataset.bucket_no_upscale}

--- a/src/musubi_tuner/dataset/dataset_config.md
+++ b/src/musubi_tuner/dataset/dataset_config.md
@@ -47,12 +47,16 @@ num_repeats = 1 # optional, default is 1. Number of times to repeat the dataset.
 
 `num_repeats` is also available. It is optional, default is 1 (no repeat). It repeats the images (or videos) that many times to expand the dataset. For example, if `num_repeats = 2` and there are 20 images in the dataset, each image will be duplicated twice (with the same caption) to have a total of 40 images. It is useful to balance the multiple datasets with different sizes.
 
+`stage` is optional (default is `1`). When Wan staged training (`--staged_training`) is enabled, datasets are consumed in ascending stage order and datasets with the same stage are mixed within that stage.
+
 <details>
 <summary>日本語</summary>
 
 `cache_directory` はオプションです。デフォルトは画像ディレクトリと同じディレクトリに設定されます。ただし、異なるデータセット間でキャッシュファイルが共有されるのを防ぐために、明示的に別のキャッシュディレクトリを設定することをお勧めします。
 
 `num_repeats` はオプションで、デフォルトは 1 です（繰り返しなし）。画像（や動画）を、その回数だけ単純に繰り返してデータセットを拡張します。たとえば`num_repeats = 2`としたとき、画像20枚のデータセットなら、各画像が2枚ずつ（同一のキャプションで）計40枚存在した場合と同じになります。異なるデータ数のデータセット間でバランスを取るために使用可能です。
+
+`stage` は任意項目で、デフォルトは `1` です。Wan の段階的学習（`--staged_training`）を有効にした場合に使用され、値が小さい段階から順番に消化され、同じ値のデータセットは同じ段階内で混在して学習されます。
 
 resolution, caption_extension, batch_size, num_repeats, enable_bucket, bucket_no_upscale は general または datasets のどちらかに設定してください。省略時は各項目のデフォルト値が使用されます。
 

--- a/src/musubi_tuner/dataset/image_video_dataset.py
+++ b/src/musubi_tuner/dataset/image_video_dataset.py
@@ -1736,7 +1736,9 @@ class ImageDataset(BaseDataset):
         return len(self.batch_manager)
 
     def __getitem__(self, idx):
-        return self.batch_manager[idx]
+        batch = self.batch_manager[idx]
+        batch["stage"] = self.stage
+        return batch
 
 
 class VideoDataset(BaseDataset):
@@ -2065,7 +2067,9 @@ class VideoDataset(BaseDataset):
         return len(self.batch_manager)
 
     def __getitem__(self, idx):
-        return self.batch_manager[idx]
+        batch = self.batch_manager[idx]
+        batch["stage"] = self.stage
+        return batch
 
 
 class DatasetGroup(torch.utils.data.ConcatDataset):
@@ -2131,16 +2135,24 @@ class StageAwareDistributedSampler(torch.utils.data.Sampler[int]):
             raise ValueError("Staged sampler received an empty dataset group")
 
         self.stage_order = sorted(self.stage_to_indices.keys())
-        self._stage_lengths = {stage: len(indices) for stage, indices in self.stage_to_indices.items()}
 
-        total_indices = sum(self._stage_lengths.values())
-        if self.drop_last:
-            self.num_samples = total_indices // self.num_replicas
-        else:
-            self.num_samples = math.ceil(total_indices / self.num_replicas)
+        self._stage_iterations_per_replica: dict[int, int] = {}
+        total_per_replica = 0
+        for stage, indices in self.stage_to_indices.items():
+            length = len(indices)
+            if length == 0:
+                continue
+            if self.drop_last:
+                per_replica = length // self.num_replicas
+            else:
+                per_replica = math.ceil(length / self.num_replicas)
+            if per_replica == 0:
+                continue
+            self._stage_iterations_per_replica[stage] = per_replica
+            total_per_replica += per_replica
 
+        self.num_samples = total_per_replica
         self.total_size = self.num_samples * self.num_replicas
-        self._total_indices = total_indices
 
     def __len__(self) -> int:
         return self.num_samples
@@ -2148,46 +2160,43 @@ class StageAwareDistributedSampler(torch.utils.data.Sampler[int]):
     def set_epoch(self, epoch: int) -> None:
         self.epoch = epoch
 
-    def _get_last_stage_indices(self) -> list[int]:
-        for stage in reversed(self.stage_order):
-            indices = self.stage_to_indices.get(stage, [])
-            if indices:
-                return list(indices)
-        return []
-
-    def _shuffle_stage_indices(self, generator: torch.Generator) -> list[int]:
-        ordered_indices: list[int] = []
+    def _build_epoch_indices(self, generator: torch.Generator) -> list[int]:
+        per_rank_indices: list[list[int]] = [[] for _ in range(self.num_replicas)]
         for stage in self.stage_order:
-            indices = list(self.stage_to_indices.get(stage, []))
-            if len(indices) == 0:
+            per_replica = self._stage_iterations_per_replica.get(stage, 0)
+            if per_replica == 0:
                 continue
-            perm = torch.randperm(len(indices), generator=generator).tolist()
-            indices = [indices[i] for i in perm]
-            ordered_indices.extend(indices)
-        return ordered_indices
+
+            stage_indices = list(self.stage_to_indices.get(stage, []))
+            if len(stage_indices) == 0:
+                continue
+
+            perm = torch.randperm(len(stage_indices), generator=generator).tolist()
+            shuffled = [stage_indices[i] for i in perm]
+
+            stage_total = per_replica * self.num_replicas
+            if len(shuffled) < stage_total:
+                # Pad within the same stage by repeating indices so every replica advances together.
+                repeat = (stage_total - len(shuffled) + len(shuffled) - 1) // len(shuffled)
+                shuffled.extend((shuffled * repeat)[: stage_total - len(shuffled)])
+            else:
+                shuffled = shuffled[:stage_total]
+
+            for replica in range(self.num_replicas):
+                per_rank_indices[replica].extend(shuffled[replica:stage_total:self.num_replicas])
+
+        return per_rank_indices[self.rank]
 
     def __iter__(self):
         g = torch.Generator()
         g.manual_seed(self.seed + self.epoch)
+        indices = self._build_epoch_indices(g)
 
-        indices = self._shuffle_stage_indices(g)
+        if self.drop_last and len(indices) > self.num_samples:
+            indices = indices[: self.num_samples]
 
-        if self.drop_last:
-            indices = indices[: self.total_size]
-        else:
-            padding_size = self.total_size - len(indices)
-            if padding_size > 0:
-                last_stage_indices = self._get_last_stage_indices()
-                if not last_stage_indices:
-                    raise ValueError("Unable to pad staged sampler because there are no stage indices")
-                repeat = (padding_size + len(last_stage_indices) - 1) // len(last_stage_indices)
-                padding = (last_stage_indices * repeat)[:padding_size]
-                indices.extend(padding)
-
-        # Subsample for this replica
-        indices = indices[self.rank : self.total_size : self.num_replicas]
         return iter(indices)
 
     @property
     def stage_lengths(self) -> dict[int, int]:
-        return dict(self._stage_lengths)
+        return dict(self._stage_iterations_per_replica)

--- a/src/musubi_tuner/dataset/image_video_dataset.py
+++ b/src/musubi_tuner/dataset/image_video_dataset.py
@@ -2135,6 +2135,7 @@ class StageAwareDistributedSampler(torch.utils.data.Sampler[int]):
             raise ValueError("Staged sampler received an empty dataset group")
 
         self.stage_order = sorted(self.stage_to_indices.keys())
+        self._stage_positions = {stage: idx for idx, stage in enumerate(self.stage_order)}
 
         self._stage_iterations_per_replica: dict[int, int] = {}
         total_per_replica = 0
@@ -2200,3 +2201,7 @@ class StageAwareDistributedSampler(torch.utils.data.Sampler[int]):
     @property
     def stage_lengths(self) -> dict[int, int]:
         return dict(self._stage_iterations_per_replica)
+
+    @property
+    def stage_positions(self) -> dict[int, int]:
+        return dict(self._stage_positions)

--- a/src/musubi_tuner/dataset/image_video_dataset.py
+++ b/src/musubi_tuner/dataset/image_video_dataset.py
@@ -1309,6 +1309,7 @@ class BaseDataset(torch.utils.data.Dataset):
         cache_directory: Optional[str] = None,
         debug_dataset: bool = False,
         architecture: str = "no_default",
+        stage: int = 1,
     ):
         self.resolution = resolution
         self.caption_extension = caption_extension
@@ -1319,6 +1320,7 @@ class BaseDataset(torch.utils.data.Dataset):
         self.cache_directory = cache_directory
         self.debug_dataset = debug_dataset
         self.architecture = architecture
+        self.stage = stage
         self.seed = None
         self.current_epoch = 0
 
@@ -1481,6 +1483,7 @@ class ImageDataset(BaseDataset):
         qwen_image_edit_control_resolution: Optional[Tuple[int, int]] = None,
         debug_dataset: bool = False,
         architecture: str = "no_default",
+        stage: int = 1,
     ):
         super(ImageDataset, self).__init__(
             resolution,
@@ -1492,6 +1495,7 @@ class ImageDataset(BaseDataset):
             cache_directory,
             debug_dataset,
             architecture,
+            stage=stage,
         )
         self.image_directory = image_directory
         self.image_jsonl_file = image_jsonl_file
@@ -1762,6 +1766,7 @@ class VideoDataset(BaseDataset):
         fp_latent_window_size: Optional[int] = 9,
         debug_dataset: bool = False,
         architecture: str = "no_default",
+        stage: int = 1,
     ):
         super(VideoDataset, self).__init__(
             resolution,
@@ -1773,6 +1778,7 @@ class VideoDataset(BaseDataset):
             cache_directory,
             debug_dataset,
             architecture,
+            stage=stage,
         )
         self.video_directory = video_directory
         self.video_jsonl_file = video_jsonl_file
@@ -2081,3 +2087,107 @@ class DatasetGroup(torch.utils.data.ConcatDataset):
     def set_max_train_steps(self, max_train_steps):
         for dataset in self.datasets:
             dataset.set_max_train_steps(max_train_steps)
+
+
+class StageAwareDistributedSampler(torch.utils.data.Sampler[int]):
+    """Sampler that iterates dataset batches stage by stage across distributed processes."""
+
+    def __init__(
+        self,
+        dataset_group: DatasetGroup,
+        num_replicas: int = 1,
+        rank: int = 0,
+        seed: int = 0,
+        drop_last: bool = False,
+    ) -> None:
+        if num_replicas <= 0:
+            raise ValueError("num_replicas must be positive")
+        if rank < 0 or rank >= num_replicas:
+            raise ValueError("rank must be in the range [0, num_replicas)")
+
+        self.dataset = dataset_group
+        self.num_replicas = num_replicas
+        self.rank = rank
+        self.seed = seed
+        self.drop_last = drop_last
+        self.epoch = 0
+
+        self.stage_to_indices: dict[int, list[int]] = {}
+        offset = 0
+        for dataset in self.dataset.datasets:
+            length = len(dataset)
+            stage = getattr(dataset, "stage", 1)
+            if length <= 0:
+                offset += length
+                continue
+
+            indices = list(range(offset, offset + length))
+            if stage not in self.stage_to_indices:
+                self.stage_to_indices[stage] = []
+            self.stage_to_indices[stage].extend(indices)
+            offset += length
+
+        if len(self.stage_to_indices) == 0:
+            raise ValueError("Staged sampler received an empty dataset group")
+
+        self.stage_order = sorted(self.stage_to_indices.keys())
+        self._stage_lengths = {stage: len(indices) for stage, indices in self.stage_to_indices.items()}
+
+        total_indices = sum(self._stage_lengths.values())
+        if self.drop_last:
+            self.num_samples = total_indices // self.num_replicas
+        else:
+            self.num_samples = math.ceil(total_indices / self.num_replicas)
+
+        self.total_size = self.num_samples * self.num_replicas
+        self._total_indices = total_indices
+
+    def __len__(self) -> int:
+        return self.num_samples
+
+    def set_epoch(self, epoch: int) -> None:
+        self.epoch = epoch
+
+    def _get_last_stage_indices(self) -> list[int]:
+        for stage in reversed(self.stage_order):
+            indices = self.stage_to_indices.get(stage, [])
+            if indices:
+                return list(indices)
+        return []
+
+    def _shuffle_stage_indices(self, generator: torch.Generator) -> list[int]:
+        ordered_indices: list[int] = []
+        for stage in self.stage_order:
+            indices = list(self.stage_to_indices.get(stage, []))
+            if len(indices) == 0:
+                continue
+            perm = torch.randperm(len(indices), generator=generator).tolist()
+            indices = [indices[i] for i in perm]
+            ordered_indices.extend(indices)
+        return ordered_indices
+
+    def __iter__(self):
+        g = torch.Generator()
+        g.manual_seed(self.seed + self.epoch)
+
+        indices = self._shuffle_stage_indices(g)
+
+        if self.drop_last:
+            indices = indices[: self.total_size]
+        else:
+            padding_size = self.total_size - len(indices)
+            if padding_size > 0:
+                last_stage_indices = self._get_last_stage_indices()
+                if not last_stage_indices:
+                    raise ValueError("Unable to pad staged sampler because there are no stage indices")
+                repeat = (padding_size + len(last_stage_indices) - 1) // len(last_stage_indices)
+                padding = (last_stage_indices * repeat)[:padding_size]
+                indices.extend(padding)
+
+        # Subsample for this replica
+        indices = indices[self.rank : self.total_size : self.num_replicas]
+        return iter(indices)
+
+    @property
+    def stage_lengths(self) -> dict[int, int]:
+        return dict(self._stage_lengths)

--- a/src/musubi_tuner/hv_train_network.py
+++ b/src/musubi_tuner/hv_train_network.py
@@ -89,6 +89,30 @@ def clean_memory_on_device(device: torch.device):
         torch.mps.empty_cache()
 
 
+def reset_compile_state():
+    """Best-effort reset of torch.compile runtime caches between curriculum stages."""
+
+    try:
+        import torch._dynamo as _dynamo  # type: ignore[attr-defined]
+    except Exception:
+        _dynamo = None
+    if _dynamo is not None:
+        try:
+            _dynamo.reset()
+        except Exception:
+            pass
+
+    try:
+        from torch._inductor import utils as _inductor_utils  # type: ignore[attr-defined]
+    except Exception:
+        _inductor_utils = None
+    if _inductor_utils is not None:
+        try:
+            _inductor_utils.clear_inductor_caches()
+        except Exception:
+            pass
+
+
 # for collate_fn: epoch and step is multiprocessing.Value
 class collator_class:
     def __init__(self, epoch, step, dataset):
@@ -1845,6 +1869,10 @@ class NetworkTrainer:
 
         staged_training = getattr(args, "staged_training", False)
         stage_sampler = None
+        stage_lengths: dict[int, int] = {}
+        stage_positions: dict[int, int] = {}
+        stage_order: list[int] = []
+        stage_unit = "batches"
         if staged_training:
             stage_map: dict[int, list[Union[ImageDataset, VideoDataset]]] = {}
             for dataset in train_dataset_group.datasets:
@@ -1861,6 +1889,7 @@ class NetworkTrainer:
 
             stage_descriptions = []
             stage_lengths = stage_sampler.stage_lengths
+            stage_positions = stage_sampler.stage_positions
             stage_unit = "batches" if accelerator.num_processes == 1 else "batches per replica"
             for stage in stage_order:
                 dataset_descriptions = []
@@ -2188,6 +2217,9 @@ class NetworkTrainer:
             else:
                 active_stage = None
 
+            stage_batch_counts: dict[int, int] = {}
+            completed_stage_logs: set[int] = set()
+
             for step, batch in enumerate(train_dataloader):
                 batch_stage_value = batch.pop("stage", None)
                 if batch_stage_value is None:
@@ -2198,21 +2230,65 @@ class NetworkTrainer:
                     batch_stage = int(batch_stage_value)
 
                 if stage_sampler is not None:
+                    stage_batch_counts.setdefault(batch_stage, 0)
+
                     if active_stage is None:
                         active_stage = batch_stage
-                        accelerator.print(f"Starting stage {batch_stage}")
+                        stage_batch_counts[batch_stage] = 0
+                        stage_target = stage_lengths.get(batch_stage)
+                        if stage_target:
+                            accelerator.print(
+                                f"Starting stage {batch_stage} ({stage_target} {stage_unit})"
+                            )
+                        else:
+                            accelerator.print(f"Starting stage {batch_stage}")
                     elif batch_stage != active_stage:
-                        if batch_stage < active_stage:
+                        prev_index = stage_positions.get(active_stage, -1)
+                        next_index = stage_positions.get(batch_stage, -1)
+
+                        if next_index == -1:
+                            logger.warning(
+                                f"Received batch from unknown stage {batch_stage}; resetting stage tracker."
+                            )
+                            active_stage = batch_stage
+                            stage_batch_counts[batch_stage] = 0
+                        elif prev_index != -1 and next_index < prev_index:
                             logger.warning(
                                 f"Received batch from stage {batch_stage} after stage {active_stage}."
                             )
                             active_stage = batch_stage
+                            stage_batch_counts[batch_stage] = 0
                         else:
-                            accelerator.print(f"Advancing to stage {batch_stage}")
+                            if prev_index != -1 and next_index > prev_index + 1:
+                                expected_idx = prev_index + 1
+                                if expected_idx < len(stage_order):
+                                    skipped_stage = stage_order[expected_idx]
+                                    logger.warning(
+                                        f"Skipping stage {skipped_stage} when advancing from stage {active_stage} to stage {batch_stage}."
+                                    )
+                            prev_count = stage_batch_counts.get(active_stage, 0)
+                            stage_target = stage_lengths.get(active_stage)
+                            next_target = stage_lengths.get(batch_stage)
+                            if stage_target:
+                                message = (
+                                    f"Completed stage {active_stage} ({prev_count}/{stage_target} {stage_unit}); advancing to stage {batch_stage}"
+                                )
+                            else:
+                                message = (
+                                    f"Completed stage {active_stage} ({prev_count} {stage_unit}); advancing to stage {batch_stage}"
+                                )
+                            if next_target:
+                                message += f" ({next_target} {stage_unit})"
+                            accelerator.print(message)
+                            completed_stage_logs.add(active_stage)
                             accelerator.wait_for_everyone()
+                            reset_compile_state()
                             clean_memory_on_device(accelerator.device)
                             accelerator.wait_for_everyone()
                             active_stage = batch_stage
+                            stage_batch_counts[batch_stage] = 0
+
+                    stage_batch_counts[batch_stage] += 1
 
                 latents = batch["latents"]
                 bsz = latents.shape[0]
@@ -2319,6 +2395,19 @@ class NetworkTrainer:
 
                 if global_step >= args.max_train_steps:
                     break
+
+            if stage_sampler is not None and active_stage is not None and active_stage not in completed_stage_logs:
+                final_count = stage_batch_counts.get(active_stage, 0)
+                stage_target = stage_lengths.get(active_stage)
+                if stage_target:
+                    accelerator.print(
+                        f"Completed stage {active_stage} ({final_count}/{stage_target} {stage_unit})"
+                    )
+                else:
+                    accelerator.print(
+                        f"Completed stage {active_stage} ({final_count} {stage_unit})"
+                    )
+                completed_stage_logs.add(active_stage)
 
             if len(accelerator.trackers) > 0:
                 logs = {"loss/epoch": loss_recorder.moving_average}

--- a/src/musubi_tuner/hv_train_network.py
+++ b/src/musubi_tuner/hv_train_network.py
@@ -1861,6 +1861,7 @@ class NetworkTrainer:
 
             stage_descriptions = []
             stage_lengths = stage_sampler.stage_lengths
+            stage_unit = "batches" if accelerator.num_processes == 1 else "batches per replica"
             for stage in stage_order:
                 dataset_descriptions = []
                 for dataset in stage_map[stage]:
@@ -1869,7 +1870,7 @@ class NetworkTrainer:
                     )
                 stage_total = stage_lengths.get(stage, 0)
                 stage_descriptions.append(
-                    f"Stage {stage} ({stage_total} batches): {', '.join(dataset_descriptions)}"
+                    f"Stage {stage} ({stage_total} {stage_unit}): {', '.join(dataset_descriptions)}"
                 )
             logger.info("Staged training order:\n" + "\n".join(stage_descriptions))
 
@@ -2183,8 +2184,36 @@ class NetworkTrainer:
 
             if stage_sampler is not None:
                 stage_sampler.set_epoch(epoch)
+                active_stage = None
+            else:
+                active_stage = None
 
             for step, batch in enumerate(train_dataloader):
+                batch_stage_value = batch.pop("stage", None)
+                if batch_stage_value is None:
+                    batch_stage = 1
+                elif isinstance(batch_stage_value, torch.Tensor):
+                    batch_stage = int(batch_stage_value.item())
+                else:
+                    batch_stage = int(batch_stage_value)
+
+                if stage_sampler is not None:
+                    if active_stage is None:
+                        active_stage = batch_stage
+                        accelerator.print(f"Starting stage {batch_stage}")
+                    elif batch_stage != active_stage:
+                        if batch_stage < active_stage:
+                            logger.warning(
+                                f"Received batch from stage {batch_stage} after stage {active_stage}."
+                            )
+                            active_stage = batch_stage
+                        else:
+                            accelerator.print(f"Advancing to stage {batch_stage}")
+                            accelerator.wait_for_everyone()
+                            clean_memory_on_device(accelerator.device)
+                            accelerator.wait_for_everyone()
+                            active_stage = batch_stage
+
                 latents = batch["latents"]
                 bsz = latents.shape[0]
                 current_step.value = global_step

--- a/src/musubi_tuner/hv_train_network.py
+++ b/src/musubi_tuner/hv_train_network.py
@@ -13,7 +13,7 @@ import random
 import time
 import json
 from multiprocessing import Value
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 import accelerate
 import numpy as np
 from packaging.version import Version
@@ -43,7 +43,13 @@ from musubi_tuner.modules.lr_schedulers import RexLR
 from musubi_tuner.modules.scheduling_flow_match_discrete import FlowMatchDiscreteScheduler
 import musubi_tuner.networks.lora as lora_module
 from musubi_tuner.dataset.config_utils import BlueprintGenerator, ConfigSanitizer
-from musubi_tuner.dataset.image_video_dataset import ARCHITECTURE_HUNYUAN_VIDEO, ARCHITECTURE_HUNYUAN_VIDEO_FULL
+from musubi_tuner.dataset.image_video_dataset import (
+    ARCHITECTURE_HUNYUAN_VIDEO,
+    ARCHITECTURE_HUNYUAN_VIDEO_FULL,
+    ImageDataset,
+    StageAwareDistributedSampler,
+    VideoDataset,
+)
 from musubi_tuner.hv_generate_video import save_images_grid, save_videos_grid, resize_image_to_bucket, encode_to_latents
 
 from blissful_tuner.blissful_logger import BlissfulLogger
@@ -1837,13 +1843,44 @@ class NetworkTrainer:
 
         # prepare dataloader
 
+        staged_training = getattr(args, "staged_training", False)
+        stage_sampler = None
+        if staged_training:
+            stage_map: dict[int, list[Union[ImageDataset, VideoDataset]]] = {}
+            for dataset in train_dataset_group.datasets:
+                stage = getattr(dataset, "stage", 1)
+                stage_map.setdefault(stage, []).append(dataset)
+
+            stage_order = sorted(stage_map.keys())
+            stage_sampler = StageAwareDistributedSampler(
+                train_dataset_group,
+                num_replicas=accelerator.num_processes,
+                rank=accelerator.process_index,
+                seed=args.seed,
+            )
+
+            stage_descriptions = []
+            stage_lengths = stage_sampler.stage_lengths
+            for stage in stage_order:
+                dataset_descriptions = []
+                for dataset in stage_map[stage]:
+                    dataset_descriptions.append(
+                        f"{dataset.__class__.__name__} (batches={len(dataset)})"
+                    )
+                stage_total = stage_lengths.get(stage, 0)
+                stage_descriptions.append(
+                    f"Stage {stage} ({stage_total} batches): {', '.join(dataset_descriptions)}"
+                )
+            logger.info("Staged training order:\n" + "\n".join(stage_descriptions))
+
         # num workers for data loader: if 0, persistent_workers is not available
         n_workers = min(args.max_data_loader_n_workers, os.cpu_count())  # cpu_count or max_data_loader_n_workers
 
         train_dataloader = torch.utils.data.DataLoader(
             train_dataset_group,
             batch_size=1,
-            shuffle=True,
+            shuffle=stage_sampler is None,
+            sampler=stage_sampler,
             collate_fn=collator,
             num_workers=n_workers,
             persistent_workers=args.persistent_data_loader_workers,
@@ -2143,6 +2180,9 @@ class NetworkTrainer:
             metadata["ss_epoch"] = str(epoch + 1)
 
             accelerator.unwrap_model(network).on_epoch_start(transformer)
+
+            if stage_sampler is not None:
+                stage_sampler.set_epoch(epoch)
 
             for step, batch in enumerate(train_dataloader):
                 latents = batch["latents"]

--- a/src/musubi_tuner/wan_train_network.py
+++ b/src/musubi_tuner/wan_train_network.py
@@ -719,6 +719,11 @@ def wan_setup_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser
     )
     parser.add_argument("--vae_cache_cpu", action="store_true", help="cache features in VAE on CPU")
     parser.add_argument("--one_frame", action="store_true", help="Use one frame sampling method for sample generation")
+    parser.add_argument(
+        "--staged_training",
+        action="store_true",
+        help="Enable staged curriculum training using dataset stage values",
+    )
 
     # Wan2.2 specific arguments
     parser.add_argument("--dit_high_noise", type=str, required=False, default=None, help="DiT checkpoint path for high noise model")


### PR DESCRIPTION
## Summary
- add a stage parameter to dataset configuration handling and surface it on dataset instances
- introduce a stage-aware sampler that preserves curriculum ordering when `--staged_training` is enabled in Wan training
- document the new stage option and expose a CLI flag for staged training

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68c88cd5f388832ba29075927c6bb8a5