### PR TITLE
Align resume bookkeeping with accelerator state

### DIFF
--- a/src/musubi_tuner/hv_train.py
+++ b/src/musubi_tuner/hv_train.py
@@ -945,7 +945,7 @@ class FineTuningTrainer:
                 init_kwargs=init_kwargs,
             )
 
-        completed_steps = int(accelerator.state.completed_steps)
+        completed_steps = train_utils.get_accelerator_completed_steps(accelerator, lr_scheduler)
         training_already_finished = completed_steps >= args.max_train_steps
         progress_bar = tqdm(
             total=args.max_train_steps,
@@ -964,6 +964,7 @@ class FineTuningTrainer:
             accelerator.print("Checkpoint already completed all requested steps. Skipping training loop.")
 
         global_step = min(completed_steps, args.max_train_steps)
+        accelerator.step = global_step
         resume_step = None
         skip_steps_in_epoch = 0
         if not training_already_finished and completed_steps > 0:
@@ -1138,6 +1139,7 @@ class FineTuningTrainer:
                 if accelerator.sync_gradients:
                     progress_bar.update(1)
                     global_step += 1
+                    accelerator.step = global_step
 
                     optimizer_eval_fn()
                     self.sample_images(

--- a/src/musubi_tuner/hv_train.py
+++ b/src/musubi_tuner/hv_train.py
@@ -945,11 +945,36 @@ class FineTuningTrainer:
                 init_kwargs=init_kwargs,
             )
 
-        # TODO skip until initial step
-        progress_bar = tqdm(range(args.max_train_steps), smoothing=0, disable=not accelerator.is_local_main_process, desc="steps")
+        completed_steps = int(accelerator.state.completed_steps)
+        training_already_finished = completed_steps >= args.max_train_steps
+        progress_bar = tqdm(
+            total=args.max_train_steps,
+            initial=min(completed_steps, args.max_train_steps),
+            smoothing=0,
+            disable=not accelerator.is_local_main_process,
+            desc="steps",
+        )
 
-        epoch_to_start = 0
-        global_step = 0
+        completed_epochs = int(getattr(accelerator.state, "completed_epochs", 0) or 0)
+        epoch_to_start = completed_epochs
+        if num_update_steps_per_epoch > 0:
+            epoch_to_start = max(epoch_to_start, completed_steps // num_update_steps_per_epoch)
+
+        if training_already_finished:
+            accelerator.print("Checkpoint already completed all requested steps. Skipping training loop.")
+
+        global_step = min(completed_steps, args.max_train_steps)
+        resume_step = None
+        skip_steps_in_epoch = 0
+        if not training_already_finished and completed_steps > 0:
+            resume_step = completed_steps * args.gradient_accumulation_steps
+            if len(train_dataloader) > 0:
+                skip_steps_in_epoch = resume_step % len(train_dataloader)
+            accelerator.print(
+                f"Resuming from global step {completed_steps} (skip {skip_steps_in_epoch} batches in current epoch)."
+            )
+        if training_already_finished:
+            epoch_to_start = num_train_epochs
         noise_scheduler = FlowMatchDiscreteScheduler(shift=args.discrete_flow_shift, reverse=True, solver="euler")
 
         loss_recorder = train_utils.LossRecorder()
@@ -995,9 +1020,10 @@ class FineTuningTrainer:
                 os.remove(old_ckpt_file)
 
         # For --sample_at_first
-        optimizer_eval_fn()
-        self.sample_images(accelerator, args, 0, global_step, accelerator.device, vae, transformer, sample_parameters)
-        optimizer_train_fn()
+        if global_step == 0:
+            optimizer_eval_fn()
+            self.sample_images(accelerator, args, 0, global_step, accelerator.device, vae, transformer, sample_parameters)
+            optimizer_train_fn()
         if len(accelerator.trackers) > 0:
             # log empty object to commit the sample images to wandb
             accelerator.log({}, step=0)
@@ -1016,6 +1042,10 @@ class FineTuningTrainer:
             current_epoch.value = epoch + 1
 
             for step, batch in enumerate(train_dataloader):
+                if resume_step is not None:
+                    if epoch == epoch_to_start and step < skip_steps_in_epoch:
+                        continue
+                    resume_step = None
                 latents, llm_embeds, llm_mask, clip_embeds = batch
                 bsz = latents.shape[0]
                 current_step.value = global_step

--- a/src/musubi_tuner/hv_train_network.py
+++ b/src/musubi_tuner/hv_train_network.py
@@ -2061,7 +2061,7 @@ class NetworkTrainer:
                 init_kwargs=init_kwargs,
             )
 
-        completed_steps = int(accelerator.state.completed_steps)
+        completed_steps = train_utils.get_accelerator_completed_steps(accelerator, lr_scheduler)
         training_already_finished = completed_steps >= args.max_train_steps
         progress_bar = tqdm(
             total=args.max_train_steps,
@@ -2079,6 +2079,7 @@ class NetworkTrainer:
             accelerator.print("Checkpoint already completed all requested steps. Skipping training loop.")
 
         global_step = min(completed_steps, args.max_train_steps)
+        accelerator.step = global_step
         resume_step = None
         skip_steps_in_epoch = 0
         if not training_already_finished and completed_steps > 0:
@@ -2236,6 +2237,7 @@ class NetworkTrainer:
                 if accelerator.sync_gradients:
                     progress_bar.update(1)
                     global_step += 1
+                    accelerator.step = global_step
 
                     # to avoid calling optimizer_eval_fn() too frequently, we call it only when we need to sample images or save the model
                     should_sampling = should_sample_images(args, global_step, epoch=None)

--- a/src/musubi_tuner/hv_train_network.py
+++ b/src/musubi_tuner/hv_train_network.py
@@ -2061,11 +2061,35 @@ class NetworkTrainer:
                 init_kwargs=init_kwargs,
             )
 
-        # TODO skip until initial step
-        progress_bar = tqdm(range(args.max_train_steps), smoothing=0, disable=not accelerator.is_local_main_process, desc="steps")
+        completed_steps = int(accelerator.state.completed_steps)
+        training_already_finished = completed_steps >= args.max_train_steps
+        progress_bar = tqdm(
+            total=args.max_train_steps,
+            initial=min(completed_steps, args.max_train_steps),
+            smoothing=0,
+            disable=not accelerator.is_local_main_process,
+            desc="steps",
+        )
 
-        epoch_to_start = 0
-        global_step = 0
+        completed_epochs = int(getattr(accelerator.state, "completed_epochs", 0) or 0)
+        epoch_to_start = completed_epochs
+        if num_update_steps_per_epoch > 0:
+            epoch_to_start = max(epoch_to_start, completed_steps // num_update_steps_per_epoch)
+        if training_already_finished:
+            accelerator.print("Checkpoint already completed all requested steps. Skipping training loop.")
+
+        global_step = min(completed_steps, args.max_train_steps)
+        resume_step = None
+        skip_steps_in_epoch = 0
+        if not training_already_finished and completed_steps > 0:
+            resume_step = completed_steps * args.gradient_accumulation_steps
+            if len(train_dataloader) > 0:
+                skip_steps_in_epoch = resume_step % len(train_dataloader)
+            accelerator.print(
+                f"Resuming from global step {completed_steps} (skip {skip_steps_in_epoch} batches in current epoch)."
+            )
+        if training_already_finished:
+            epoch_to_start = num_train_epochs
         noise_scheduler = FlowMatchDiscreteScheduler(shift=args.discrete_flow_shift, reverse=True, solver="euler")
 
         loss_recorder = train_utils.LossRecorder()
@@ -2145,6 +2169,10 @@ class NetworkTrainer:
             accelerator.unwrap_model(network).on_epoch_start(transformer)
 
             for step, batch in enumerate(train_dataloader):
+                if resume_step is not None:
+                    if epoch == epoch_to_start and step < skip_steps_in_epoch:
+                        continue
+                    resume_step = None
                 latents = batch["latents"]
                 bsz = latents.shape[0]
                 current_step.value = global_step

--- a/src/musubi_tuner/qwen_image_train.py
+++ b/src/musubi_tuner/qwen_image_train.py
@@ -436,7 +436,7 @@ class QwenImageTrainer(QwenImageNetworkTrainer):
                 init_kwargs=init_kwargs,
             )
 
-        completed_steps = int(accelerator.state.completed_steps)
+        completed_steps = train_utils.get_accelerator_completed_steps(accelerator, lr_scheduler)
         training_already_finished = completed_steps >= args.max_train_steps
         progress_bar = tqdm(
             total=args.max_train_steps,
@@ -454,6 +454,7 @@ class QwenImageTrainer(QwenImageNetworkTrainer):
             accelerator.print("Checkpoint already completed all requested steps. Skipping training loop.")
 
         global_step = min(completed_steps, args.max_train_steps)
+        accelerator.step = global_step
         resume_step = None
         skip_steps_in_epoch = 0
         if not training_already_finished and completed_steps > 0:
@@ -607,6 +608,7 @@ class QwenImageTrainer(QwenImageNetworkTrainer):
                 if accelerator.sync_gradients:
                     progress_bar.update(1)
                     global_step += 1
+                    accelerator.step = global_step
 
                     # to avoid calling optimizer_eval_fn() too frequently, we call it only when we need to sample images or save the model
                     should_sampling = should_sample_images(args, global_step, epoch=None)

--- a/src/musubi_tuner/qwen_image_train.py
+++ b/src/musubi_tuner/qwen_image_train.py
@@ -436,11 +436,35 @@ class QwenImageTrainer(QwenImageNetworkTrainer):
                 init_kwargs=init_kwargs,
             )
 
-        # TODO skip until initial step
-        progress_bar = tqdm(range(args.max_train_steps), smoothing=0, disable=not accelerator.is_local_main_process, desc="steps")
+        completed_steps = int(accelerator.state.completed_steps)
+        training_already_finished = completed_steps >= args.max_train_steps
+        progress_bar = tqdm(
+            total=args.max_train_steps,
+            initial=min(completed_steps, args.max_train_steps),
+            smoothing=0,
+            disable=not accelerator.is_local_main_process,
+            desc="steps",
+        )
 
-        epoch_to_start = 0
-        global_step = 0
+        completed_epochs = int(getattr(accelerator.state, "completed_epochs", 0) or 0)
+        epoch_to_start = completed_epochs
+        if num_update_steps_per_epoch > 0:
+            epoch_to_start = max(epoch_to_start, completed_steps // num_update_steps_per_epoch)
+        if training_already_finished:
+            accelerator.print("Checkpoint already completed all requested steps. Skipping training loop.")
+
+        global_step = min(completed_steps, args.max_train_steps)
+        resume_step = None
+        skip_steps_in_epoch = 0
+        if not training_already_finished and completed_steps > 0:
+            resume_step = completed_steps * args.gradient_accumulation_steps
+            if len(train_dataloader) > 0:
+                skip_steps_in_epoch = resume_step % len(train_dataloader)
+            accelerator.print(
+                f"Resuming from global step {completed_steps} (skip {skip_steps_in_epoch} batches in current epoch)."
+            )
+        if training_already_finished:
+            epoch_to_start = num_train_epochs
         noise_scheduler = FlowMatchDiscreteScheduler(shift=args.discrete_flow_shift, reverse=True, solver="euler")
 
         loss_recorder = train_utils.LossRecorder()
@@ -525,6 +549,10 @@ class QwenImageTrainer(QwenImageNetworkTrainer):
             metadata["ss_epoch"] = str(epoch + 1)
 
             for step, batch in enumerate(train_dataloader):
+                if resume_step is not None:
+                    if epoch == epoch_to_start and step < skip_steps_in_epoch:
+                        continue
+                    resume_step = None
                 latents = batch["latents"]
                 current_step.value = global_step
 

--- a/src/musubi_tuner/utils/train_utils.py
+++ b/src/musubi_tuner/utils/train_utils.py
@@ -11,6 +11,63 @@ from musubi_tuner.utils import huggingface_utils
 logger = BlissfulLogger(__name__, "green")
 
 
+def get_accelerator_completed_steps(
+    accelerator: accelerate.Accelerator, lr_scheduler=None
+) -> int:
+    """Best effort helper to recover the number of completed optimizer steps."""
+
+    state = getattr(accelerator, "state", None)
+    if state is not None:
+        completed = getattr(state, "completed_steps", None)
+        if completed is not None:
+            try:
+                return int(completed)
+            except (TypeError, ValueError):
+                logger.warning("failed to coerce accelerator.state.completed_steps to int")
+
+    step_attr = getattr(accelerator, "step", None)
+    if step_attr is not None:
+        try:
+            step_value = int(step_attr)
+        except (TypeError, ValueError):
+            logger.warning("failed to coerce accelerator.step to int")
+        else:
+            if step_value > 0:
+                logger.debug("falling back to accelerator.step for completed step count")
+                return step_value
+
+    if lr_scheduler is not None:
+        schedulers = (
+            lr_scheduler
+            if isinstance(lr_scheduler, (list, tuple, set))
+            else (lr_scheduler,)
+        )
+        for scheduler in schedulers:
+            if scheduler is None:
+                continue
+            try:
+                scheduler_state = scheduler.state_dict()
+            except Exception:
+                scheduler_state = None
+            if scheduler_state is not None:
+                last_epoch = scheduler_state.get("last_epoch")
+                if last_epoch is None and hasattr(scheduler, "last_epoch"):
+                    last_epoch = getattr(scheduler, "last_epoch")
+                if last_epoch is not None:
+                    try:
+                        last_epoch_value = int(last_epoch)
+                    except (TypeError, ValueError):
+                        logger.warning("failed to coerce lr_scheduler.last_epoch to int")
+                    else:
+                        if last_epoch_value > 0:
+                            logger.debug(
+                                "falling back to lr_scheduler state for completed step count"
+                            )
+                            return last_epoch_value
+
+    return 0
+
+
 # checkpointファイル名
 EPOCH_STATE_NAME = "{}-{:06d}-state"
 EPOCH_FILE_NAME = "{}-{:06d}"


### PR DESCRIPTION
## Summary
- initialize progress tracking from `accelerator.state.completed_steps` across Hunyuan Video and Qwen training entry points
- skip already-consumed dataloader batches and start epochs based on the restored step when resuming
- avoid re-running the initial sampling hook when resuming and gracefully handle fully completed checkpoints

## Testing
- python -m compileall src/musubi_tuner/hv_train.py src/musubi_tuner/hv_train_network.py src/musubi_tuner/qwen_image_train.py

------
https://chatgpt.com/codex/tasks/task_e_68ce064703ac832baeed57a44cac82d3